### PR TITLE
dev: add forknet

### DIFF
--- a/docker-compose.forknet.yml
+++ b/docker-compose.forknet.yml
@@ -1,0 +1,110 @@
+name: forknet-server
+  
+services: 
+  enforcer:   
+    profiles:
+      - forknet
+    ports:
+      - "127.0.0.1:8123:8123" # JSON-RPC, only available from host machine
+
+    secrets:
+      - source: bitcoind-forknet-cookie
+        target: /daemon-dir/.cookie
+
+    command: 
+      - --log-format=json
+      - --log-level=debug
+      - --node-rpc-addr=host.docker.internal:18301
+      - --node-rpc-cookie-path=/daemon-dir/.cookie
+      - --serve-grpc-addr=0.0.0.0:50051 # Expose over 0.0.0.0 so that other services can connect to it
+      - --serve-rpc-addr=0.0.0.0:8123 # Expose over 0.0.0.0 so that other services can connect to it
+      - --node-zmq-addr-sequence=tcp://host.docker.internal:29000
+
+  mempool-db:
+    profiles:
+      - forknet
+  
+  mempool-web: 
+    profiles:
+      - forknet
+
+  mempool-api:
+    profiles:
+      - forknet
+    secrets:
+      - source: bitcoind-forknet-cookie
+        target: /daemon-dir/.cookie
+
+    environment:
+      MEMPOOL_NETWORK: mainnet
+      CORE_RPC_HOST: host.docker.internal
+      CORE_RPC_PORT: 18301
+      CORE_RPC_USERNAME: ''
+      CORE_RPC_PASSWORD: ''
+      CORE_RPC_COOKIE: "true"
+      CORE_RPC_COOKIE_PATH: "/daemon-dir/.cookie"
+
+  electrs:
+    profiles:
+      - forknet
+    volumes: 
+      # Mount this into something different from the baseline 
+      # Compose file, otherwise we'll overwrite our own mount
+      - electrs-forknet-data:/forknet
+    secrets: 
+      - source: bitcoind-forknet-cookie
+        target: /daemon-dir/.cookie
+
+    command:
+      - -vv # pretty verbose logging
+      - --timestamp
+      - --daemon-rpc-addr=host.docker.internal:18301
+      - --jsonrpc-import
+      - --db-dir=/forknet/db
+      - --daemon-dir=/daemon-dir
+      - --network=mainnet
+      - --http-addr=0.0.0.0:3000
+      - --electrum-rpc-addr=0.0.0.0:50001
+      - --electrum-txs-limit=30000
+      - --cors=*
+  
+  faucet-backend: 
+    profiles:
+      - forknet
+    secrets:
+      - source: bitcoind-forknet-cookie
+        target: /cookie
+    command:
+      - faucetd
+      - --bitcoincore.address=host.docker.internal:18301
+      - --bitcoincore.cookie=/cookie
+      - --enforcer.url=http://enforcer:50051
+      - --listen=0.0.0.0:8082
+    
+  faucet-frontend:
+    profiles:
+      - forknet
+    environment: 
+      API_BASE_URL: http://faucet-backend:8082
+      METADATA_BASE_URL: https://node.forknet.drivechain.info
+  
+  busybox: 
+    volumes: 
+      - electrs-forknet-data:/electrs-forknet-data
+
+# Paths to secrets refer to the (remote) host machine. 
+secrets: 
+  # IMPORTANT: this needs to be a file WITHOUT a trailing newline
+  bitcoind-forknet-cookie: 
+    file: /data/secrets/bitcoind-forknet-cookie.txt
+
+volumes:
+  # Paths in volume mounts work poorly with remote Docker contexts.
+  # We therefore specify an external volume. This can be created with 
+  # the following command on the machine hosting the Docker context:
+  # $ docker volume create \
+  #  --driver local --opt type=none \
+  #  --opt o=bind --opt device=/data/electrs \
+  #  electrs-forknet-data 
+  electrs-forknet-data:
+    external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,13 +30,14 @@ services:
       - -rest
 
   enforcer: 
-    image: ghcr.io/layertwo-labs/bip300301_enforcer:sha-7604e13
+    image: ghcr.io/layertwo-labs/bip300301_enforcer:sha-65ebb34
     pull_policy: always
     restart: unless-stopped
-    # Adjust these lines to adjust the RUST_LOG (or any other!) env var
     environment: 
-      RUST_LOG: trace,h2=info,hyper_util=info
+      RUST_LOG: debug,h2=info,hyper_util=info
       RUST_BACKTRACE: 1
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
     healthcheck:
        test: ["CMD", "grpc_health_probe", "-service=cusf.mainchain.v1.ValidatorService", "-addr=localhost:50051"]
@@ -199,6 +200,8 @@ services:
       - 8080:8080 # should be reachable externally
 
   mempool-api:
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     depends_on: [mempool-db]
 
     # conf: https://github.com/mempool/mempool/blob/e3c3f31ddbf9543db12ef4f7e5032566757d31f9/backend/mempool-config.sample.json#
@@ -232,11 +235,13 @@ services:
   # TODO: how do we enable SSL here?
   electrs:
     image: mempool/electrs
-    # TODO: find something that works here with what's installed on the box
-    # healthcheck:
-    #  test: ["CMD", "curl", "--fail", "http://localhost:3000/blocks/tip/hash"]
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "http://localhost:3000/blocks/tip/height"]
     environment:
       RUST_BACKTRACE: 1
+
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
     restart: unless-stopped
     ports:
@@ -307,8 +312,15 @@ services:
       API_BASE_URL: https://node.drivechain.info/api
       METADATA_BASE_URL: https://node.drivechain.info
     pull_policy: always
-    # Find image-tags here: https://github.com/LayerTwo-Labs/faucet-frontend/pkgs/container/faucet-frontend
-    image: ghcr.io/layertwo-labs/faucet-frontend-signet:sha-776a9a9
+    # We want to avoid specifying tags for both signet and forknet by themselves, so we
+    # try to be a bit clever here. Perhaps too clever? Anyways: COMPOSE_PROJECT_NAME can 
+    # interpolated into the image name, and this is automatically set when running. This 
+    # means that we don't have to provide a .env file, or specify an env var on the 
+    # command line. 
+    # Find image-tags here: 
+    #   Signet: https://github.com/LayerTwo-Labs/faucet-frontend-signet-server/pkgs/container/faucet-frontend
+    #   Forknet: https://github.com/LayerTwo-Labs/faucet-frontend-forknet-server/pkgs/container/faucet-frontend
+    image: ghcr.io/layertwo-labs/faucet-frontend-${COMPOSE_PROJECT_NAME}:pr-1399
 
   # Can be used to run a container with the same volumes as the other services. 
   # $ docker compose run --rm busybox sh

--- a/justfile
+++ b/justfile
@@ -1,3 +1,9 @@
+compose-forknet *args="":
+    docker --context l2l-forknet compose \
+        --profile forknet \
+        -f docker-compose.yml \
+        -f docker-compose.forknet.yml {{ args }}
+
 get-latest-image service:
     #! /usr/bin/env bash
     if ! which uv > /dev/null; then


### PR DESCRIPTION
Adds a new forknet compose file. The intention is for this to be used together with the base file, through the `just compose-forknet` recipe. I try to be mindful here of how we're including RPC credentials etc. In the base conf this is hard coded, whereas in this I use proper secrets. I have a plan to split off the signet stuff into its own file, and do the same thing there with the credentials. 